### PR TITLE
Change `RecentArticleAction` format

### DIFF
--- a/LobsterMVVMExample.xcodeproj/project.pbxproj
+++ b/LobsterMVVMExample.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		543E7597DA711C3F8C782EC0 /* Pods_LobsterMVVMExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94619266D1D83D7C60819F93 /* Pods_LobsterMVVMExample.framework */; };
 		BCEA271845FD14DBF5AFAFD3 /* Pods_LobsterMVVMExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD5E3CB3DDA71C84DEEE123C /* Pods_LobsterMVVMExampleTests.framework */; };
+		E897625723A2E0DE009CB7CB /* ViewLifeCycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E897625623A2E0DE009CB7CB /* ViewLifeCycle.swift */; };
+		E897625A23A2E1E7009CB7CB /* ViewLifeCycleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E897625923A2E1E7009CB7CB /* ViewLifeCycleViewController.swift */; };
 		F7612ABC23A24ABF008CBF0A /* MockLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7612ABB23A24ABF008CBF0A /* MockLocalization.swift */; };
 		F7612AC323A24B71008CBF0A /* RecentArticleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7612AC223A24B71008CBF0A /* RecentArticleViewModelTests.swift */; };
 		F7612AC623A24BA9008CBF0A /* Article+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7612AC523A24BA9008CBF0A /* Article+Stub.swift */; };
@@ -75,6 +77,8 @@
 		D3FF15F8B0CD644380DA8084 /* Pods-LobsterMVVMExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LobsterMVVMExample.release.xcconfig"; path = "Target Support Files/Pods-LobsterMVVMExample/Pods-LobsterMVVMExample.release.xcconfig"; sourceTree = "<group>"; };
 		DD5E3CB3DDA71C84DEEE123C /* Pods_LobsterMVVMExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LobsterMVVMExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4241171D812758614A5203B /* Pods-LobsterMVVMExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LobsterMVVMExampleTests.release.xcconfig"; path = "Target Support Files/Pods-LobsterMVVMExampleTests/Pods-LobsterMVVMExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		E897625623A2E0DE009CB7CB /* ViewLifeCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLifeCycle.swift; sourceTree = "<group>"; };
+		E897625923A2E1E7009CB7CB /* ViewLifeCycleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLifeCycleViewController.swift; sourceTree = "<group>"; };
 		F7612AB923A248B2008CBF0A /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F7612ABB23A24ABF008CBF0A /* MockLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalization.swift; sourceTree = "<group>"; };
 		F7612AC223A24B71008CBF0A /* RecentArticleViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentArticleViewModelTests.swift; sourceTree = "<group>"; };
@@ -168,6 +172,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E897625823A2E1B0009CB7CB /* ViewLifeCycleViewController */ = {
+			isa = PBXGroup;
+			children = (
+				E897625623A2E0DE009CB7CB /* ViewLifeCycle.swift */,
+				E897625923A2E1E7009CB7CB /* ViewLifeCycleViewController.swift */,
+			);
+			path = ViewLifeCycleViewController;
+			sourceTree = "<group>";
+		};
 		F7612ABA23A24A81008CBF0A /* Mock */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +228,7 @@
 		F7AE0B8123A1625700C9B391 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				E897625823A2E1B0009CB7CB /* ViewLifeCycleViewController */,
 				F7AE0B8723A1648C00C9B391 /* UIViewController+ContainerView.swift */,
 				F7C8AAFC23A23C49004D268D /* UITableViewCell+Util.swift */,
 				F7AE0B8223A1625D00C9B391 /* Loading */,
@@ -657,6 +671,7 @@
 				F7EA87F823A118330091EDAD /* HTTPMethod.swift in Sources */,
 				F7EA883B23A156A30091EDAD /* RecentArticleViewModel.swift in Sources */,
 				F7EA881923A133EA0091EDAD /* RepositoryResult.swift in Sources */,
+				E897625723A2E0DE009CB7CB /* ViewLifeCycle.swift in Sources */,
 				F7C8AAFD23A23C49004D268D /* UITableViewCell+Util.swift in Sources */,
 				F7AE0B8823A1648C00C9B391 /* UIViewController+ContainerView.swift in Sources */,
 				F7EA883523A14CB50091EDAD /* RecentArticleAction.swift in Sources */,
@@ -678,6 +693,7 @@
 				F7E6DA5423A1A27D00E4EE93 /* LoadingView+Rx.swift in Sources */,
 				F7EA881723A12EB50091EDAD /* NetworkArticleCollectionRepository.swift in Sources */,
 				F7EA87D423A117F60091EDAD /* SceneDelegate.swift in Sources */,
+				E897625A23A2E1E7009CB7CB /* ViewLifeCycleViewController.swift in Sources */,
 				F7EA881523A12E740091EDAD /* Article.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LobsterMVVMExample/Foundation/View/ViewLifeCycleViewController/ViewLifeCycle.swift
+++ b/LobsterMVVMExample/Foundation/View/ViewLifeCycleViewController/ViewLifeCycle.swift
@@ -1,0 +1,18 @@
+//
+//  ViewLifeCycle.swift
+//  LobsterMVVMExample
+//
+//  Created by Jean-Pierre Alary on 12/12/2019.
+//  Copyright © 2019 Jean-Pierre Alary. All rights reserved.
+//
+
+/**
+ # Enumeration of view life cycle steps in view controller class.
+ */
+enum ViewLifeCycle {
+    case viewDidLoad
+    case viewWillAppear
+    case viewDidAppear
+    case viewWillDisappear
+    case viewDidDisappear
+}

--- a/LobsterMVVMExample/Foundation/View/ViewLifeCycleViewController/ViewLifeCycleViewController.swift
+++ b/LobsterMVVMExample/Foundation/View/ViewLifeCycleViewController/ViewLifeCycleViewController.swift
@@ -1,0 +1,50 @@
+//
+//  ViewLifeCycleViewController.swift
+//  LobsterMVVMExample
+//
+//  Created by Jean-Pierre Alary on 12/12/2019.
+//  Copyright © 2019 Jean-Pierre Alary. All rights reserved.
+//
+
+import UIKit
+import RxSwift
+
+/**
+ # Subclass of `UIViewController` which exposes a `PublishSubject<ViewLifeCycle>` which follows view life cycle.
+ */
+class ViewLifeCycleViewController: UIViewController {
+    let disposeBag = DisposeBag()
+    let viewLifeCycle = PublishSubject<ViewLifeCycle>()
+    
+    // MARK: - View life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        viewLifeCycle.onNext(.viewDidLoad)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        viewLifeCycle.onNext(.viewWillAppear)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        viewLifeCycle.onNext(.viewDidAppear)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        viewLifeCycle.onNext(.viewWillDisappear)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        viewLifeCycle.onNext(.viewDidDisappear)
+    }
+}

--- a/LobsterMVVMExample/Scene/ArticleCollection/Recent/Model/Interactor/RecentArticleInteractor.swift
+++ b/LobsterMVVMExample/Scene/ArticleCollection/Recent/Model/Interactor/RecentArticleInteractor.swift
@@ -30,24 +30,24 @@ struct RecentArticleInteractor: Interactor {
     // MARK: - Interactor
     
     func perform(action: RecentArticleAction) -> Observable<RecentArticleResult> {
-        switch action {
-        case .viewWillAppear:
-            return repository
-                .getLatest()
-                .map { result in
-                    switch result {
-                    case .value(let articles):
-                        return .articles(articles.map { RecentArticleViewModel(localization: self.localization, article: $0) })
-                    case .notFound:
-                        return .error(message: self.localization.translate(for: Constant.TranslationKey.emptyCollection))
-                    case .error(let error):
-                        guard let appError = error as? AppError else {
-                            fatalError("\(#function) - error from repository should be instance of `AppError`")
+        action
+            .viewWillAppear
+            .flatMap { _ in
+                self.repository.getLatest()
+                    .map { result in
+                        switch result {
+                        case .value(let articles):
+                            return .articles(articles.map { RecentArticleViewModel(localization: self.localization, article: $0) })
+                        case .notFound:
+                            return .error(message: self.localization.translate(for: Constant.TranslationKey.emptyCollection))
+                        case .error(let error):
+                            guard let appError = error as? AppError else {
+                                fatalError("\(#function) - error from repository should be instance of `AppError`")
+                            }
+                            return .error(message: appError.message(with: self.localization))
                         }
-                        return .error(message: appError.message(with: self.localization))
-                    }
                 }
                 .startWith(.loading)
-        }
+            }
     }
 }

--- a/LobsterMVVMExample/Scene/ArticleCollection/Recent/Model/Interactor/RecentTitleInteractor.swift
+++ b/LobsterMVVMExample/Scene/ArticleCollection/Recent/Model/Interactor/RecentTitleInteractor.swift
@@ -26,10 +26,8 @@ struct RecentTitleInteractor: Interactor {
     // MARK: - Interactor
     
     func perform(action: RecentArticleAction) -> Observable<RecentArticleResult> {
-        guard case .viewWillAppear = action else {
-            return .empty()
-        }
-
-        return .just(.recentTitle(localization.translate(for: TranslationKey.title)))
+        action
+            .viewWillAppear
+            .map { _ in .recentTitle(self.localization.translate(for: TranslationKey.title)) }
     }
 }

--- a/LobsterMVVMExample/Scene/ArticleCollection/Recent/Model/RecentArticleAction.swift
+++ b/LobsterMVVMExample/Scene/ArticleCollection/Recent/Model/RecentArticleAction.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Jean-Pierre Alary. All rights reserved.
 //
 
-enum RecentArticleAction {
-    case viewWillAppear
+import RxSwift
+
+struct RecentArticleAction {
+    let viewWillAppear: Observable<Void>
 }

--- a/LobsterMVVMExampleTests/Scene/ArticleCollection/Recent/RecentArticleInteractorTests.swift
+++ b/LobsterMVVMExampleTests/Scene/ArticleCollection/Recent/RecentArticleInteractorTests.swift
@@ -12,23 +12,25 @@ import RxSwift
 
 final class RecentArticleInteractorTests: XCTestCase {
     
-    func test_givenErrorFromRepository_whenPerformViewWillAppear_thenShouldReturnLoadingAndErrorCases() {
+    func test_givenErrorFromRepository_whenViewWillAppearActionIsTriggered_thenShouldReturnLoadingAndErrorCases() {
         let disposeBag = DisposeBag()
+        let viewWillAppear = PublishSubject<Void>()
         
         // Given
         let interactor = RecentArticleInteractor(
             repository: MockArticleCollectionRepository(getLatest: .just(.error(StubAppError()))),
             localization: MockLocalization()
         )
-        
-        // When
         var results: [RecentArticleResult] = []
         interactor
-            .perform(action: .viewWillAppear)
+            .perform(action: RecentArticleAction(viewWillAppear: viewWillAppear))
             .subscribe(onNext: { result in
                 results.append(result)
             })
             .disposed(by: disposeBag)
+
+        // When
+        viewWillAppear.onNext(())
         
         // Then
         XCTAssertEqual(
@@ -40,23 +42,25 @@ final class RecentArticleInteractorTests: XCTestCase {
         )
     }
     
-    func test_givenNotFoundFromRepository_whenPerformViewWillAppear_thenShouldReturnLoadingAndErrorCases() {
+    func test_givenNotFoundFromRepository_whenViewWillAppearActionIsTriggered_thenShouldReturnLoadingAndErrorCases() {
         let disposeBag = DisposeBag()
+        let viewWillAppear = PublishSubject<Void>()
         
         // Given
         let interactor = RecentArticleInteractor(
             repository: MockArticleCollectionRepository(getLatest: .just(.notFound)),
             localization: MockLocalization()
         )
-        
-        // When
         var results: [RecentArticleResult] = []
         interactor
-            .perform(action: .viewWillAppear)
+            .perform(action: RecentArticleAction(viewWillAppear: viewWillAppear))
             .subscribe(onNext: { result in
                 results.append(result)
             })
             .disposed(by: disposeBag)
+            
+        // When
+        viewWillAppear.onNext(())
         
         // Then
         XCTAssertEqual(
@@ -68,23 +72,25 @@ final class RecentArticleInteractorTests: XCTestCase {
         )
     }
     
-    func test_givenArticlesFromRepository_whenPerformViewWillAppear_thenShouldReturnLoadingAndArticleCases() {
+    func test_givenArticlesFromRepository_whenViewWillAppearActionIsTriggered_thenShouldReturnLoadingAndArticleCases() {
         let disposeBag = DisposeBag()
+        let viewWillAppear = PublishSubject<Void>()
         
         // Given
         let interactor = RecentArticleInteractor(
             repository: MockArticleCollectionRepository(getLatest: .just(.value([Article.defaultStub, Article.defaultStub]))),
             localization: MockLocalization()
         )
-        
-        // When
         var results: [RecentArticleResult] = []
         interactor
-            .perform(action: .viewWillAppear)
+            .perform(action: RecentArticleAction(viewWillAppear: viewWillAppear))
             .subscribe(onNext: { result in
                 results.append(result)
             })
             .disposed(by: disposeBag)
+        
+        // When
+        viewWillAppear.onNext(())
         
         // Then
         XCTAssertEqual(

--- a/LobsterMVVMExampleTests/Scene/ArticleCollection/Recent/RecentTitleInteractorTests.swift
+++ b/LobsterMVVMExampleTests/Scene/ArticleCollection/Recent/RecentTitleInteractorTests.swift
@@ -12,20 +12,22 @@ import RxSwift
 
 final class RecentTitleInteractorTests: XCTestCase {
     
-    func test_givenMockLocalization_whenPerformViewWillAppearAction_thenShouldReturnTitleCase() {
+    func test_givenMockLocalization_whenViewWillAppearActionIsTriggered_thenShouldReturnTitleCase() {
         let disposeBag = DisposeBag()
+        let viewWillAppear = PublishSubject<Void>()
         
         // Given
         let interactor = RecentTitleInteractor(localization: MockLocalization())
-        
-        // When
         var results: [RecentArticleResult] = []
         interactor
-            .perform(action: .viewWillAppear)
+            .perform(action: RecentArticleAction(viewWillAppear: viewWillAppear))
             .subscribe(onNext: { result in
                 results.append(result)
             })
             .disposed(by: disposeBag)
+        
+        // When
+        viewWillAppear.onNext(())
         
         // Then
         XCTAssertEqual(


### PR DESCRIPTION
Recent article action is now defines as a structure with one property type of `Observable<Void>` which represents when view will appear.

In this commit, there is also a subclass of `UIViewController` called `ViewLifeCycleViewController`: this class can be use as parent view controller to obtain a publish subject, binded on the view life cycle.